### PR TITLE
feat: disable security hub alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,24 @@ For detailed instructions on setting up federation you can read more on this [bl
 The baseline configures CloudWatch Events that listen and alerts on several types of events.
 
 - GuardDuty Findings with severity Medium or Higher (Above 4)
+
+The following events are disabled by default but to avoid too much noise but can be enabled by setting the `SecurityHubEvents` parameter to true in the `security-regional` template.
+
 - Security Hub Findings - Imported
 - Security Hub Insight Results
 
 [List of Security Hub Types](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cloudwatch-events.html#securityhub-cwe-integration-types)
 
-These can be tweaked in the Regional Security template.
+Note: It is recommended that you regularly view the status in the [Security Hub Dashboard](console.aws.amazon.com/securityhub/home) in relevant regions for an overview of your security status.
 
 ### Cleanup
 
-In order to clean up the MSB delete CloudFormation stacks starting from regional stacks and then the global ones, like in the example below: 
+In order to clean up the MSB delete CloudFormation stacks starting from regional stacks and then the global ones, like in the example below:
 
 ```sh
-aws cloudformation delete-stack msb-security-eu-west-1 [ --profile yourawsprofile ] 
-aws cloudformation delete-stack msb-vpc-eu-west-1 [ --profile yourawsprofile ] 
-aws cloudformation delete-stack msb-logging-eu-west-1 [ --profile yourawsprofile ] 
-aws cloudformation delete-stack msb-logging-global [ --profile yourawsprofile ] 
-aws cloudformation delete-stack msb-iam-global [ --profile yourawsprofile ] 
+aws cloudformation delete-stack msb-security-eu-west-1 [ --profile yourawsprofile ]
+aws cloudformation delete-stack msb-vpc-eu-west-1 [ --profile yourawsprofile ]
+aws cloudformation delete-stack msb-logging-eu-west-1 [ --profile yourawsprofile ]
+aws cloudformation delete-stack msb-logging-global [ --profile yourawsprofile ]
+aws cloudformation delete-stack msb-iam-global [ --profile yourawsprofile ]
 ```

--- a/cfn/security-regional.yaml
+++ b/cfn/security-regional.yaml
@@ -17,9 +17,19 @@ Metadata:
         default: Notification Address
 
 Parameters:
+
   NotificationEmail:
     Type: String
     Description: E-mail address to receive security notifications.
+
+  SecurityHubEvents:
+    Type: String
+    Description: Set to true if you want to push Security Hub Events to the SNS topic.
+    Default: false
+    AllowedValues: [true, false]
+
+Conditions:
+  SendSecurityHubEvents: !Equals [!Ref SecurityHubEvents, true]
 
 Resources: 
 
@@ -182,79 +192,81 @@ Resources:
                 responseData['reason'] = 'No changes required.'
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, physicalResourceId)
 
-  # # Security Hub Notifications (disabled by default)
-  # SecurityHubImportedCWEvent:
-  #   Type: AWS::Events::Rule
-  #   Properties:
-  #       Description: GuardDuty Event Rule
-  #       EventPattern:
-  #         source:
-  #           - aws.securityhub
-  #         detail-type:
-  #           - Security Hub Findings - Imported
-  #       State: ENABLED
-  #       Targets:
-  #           - 
-  #             Arn: !Ref NotificationTopic
-  #             Id: TargetSNSTopic
-  #             InputTransformer:
-  #               InputPathsMap:
-  #                 findingTime: $.detail.findings[0].updatedAt
-  #                 findingType: $.detail.findings[0].Types[0]
-  #                 findingId: $.detail.findings[0].Resources[0].Region
-  #                 findingTitle: $.detail.findings[0].Title
-  #                 findingDescription: $.detail.findings[0].Description
-  #                 complianceStatus: $.detail.findings[0].Compliance.Status
-  #                 affectedResources: $.detail.findings[0].Resources
-  #                 recommendationText: $.detail.findings[0].Recommendation.Text
-  #                 recommendationUrl: $.detail.findings[0].Recommendation.Url
-  #               InputTemplate: |
-  #                 "<findingTitle>"
-  #                 "Finding: <findingType>"
-  #                 "Date/Time: <findingTime>"
-  #                 "Finding ID: <findingId>"
-  #                 "Compliance Status: <complianceStatus>"
-  #                 "Description: <findingDescription>"
-  #                 ""
-  #                 "Affected Resource:"
-  #                 "<affectedResources>"
-  #                 ""
-  #                 "<recommendationText>"
-  #                 "<recommendationUrl>"
+  # Security Hub Notifications (disabled by default)
+  SecurityHubImportedCWEvent:
+    Condition: SendSecurityHubEvents
+    Type: AWS::Events::Rule
+    Properties:
+        Description: GuardDuty Event Rule
+        EventPattern:
+          source:
+            - aws.securityhub
+          detail-type:
+            - Security Hub Findings - Imported
+        State: ENABLED
+        Targets:
+            - 
+              Arn: !Ref NotificationTopic
+              Id: TargetSNSTopic
+              InputTransformer:
+                InputPathsMap:
+                  findingTime: $.detail.findings[0].updatedAt
+                  findingType: $.detail.findings[0].Types[0]
+                  findingId: $.detail.findings[0].Resources[0].Region
+                  findingTitle: $.detail.findings[0].Title
+                  findingDescription: $.detail.findings[0].Description
+                  complianceStatus: $.detail.findings[0].Compliance.Status
+                  affectedResources: $.detail.findings[0].Resources
+                  recommendationText: $.detail.findings[0].Recommendation.Text
+                  recommendationUrl: $.detail.findings[0].Recommendation.Url
+                InputTemplate: |
+                  "<findingTitle>"
+                  "Finding: <findingType>"
+                  "Date/Time: <findingTime>"
+                  "Finding ID: <findingId>"
+                  "Compliance Status: <complianceStatus>"
+                  "Description: <findingDescription>"
+                  ""
+                  "Affected Resource:"
+                  "<affectedResources>"
+                  ""
+                  "<recommendationText>"
+                  "<recommendationUrl>"
 
-  # SecurityHubInsightsCWEvent:
-  #   Type: AWS::Events::Rule
-  #   Properties:
-  #       Description: GuardDuty Event Rule
-  #       EventPattern:
-  #         source:
-  #           - aws.securityhub
-  #         detail-type:
-  #           - Security Hub Insight Results
-  #       State: ENABLED
-  #       Targets:
-  #           - 
-  #             Arn: !Ref NotificationTopic
-  #             Id: TargetSNSTopic
-  #             InputTransformer:
-  #               InputPathsMap:
-  #                 insightTime: $.time
-  #                 actionName: $.detail.actionName
-  #                 actionDescription: $.detail.actionDescription
-  #                 insightArn: $.detail.insightArn
-  #                 insightName: $.detail.insightName
-  #                 resultType: $.detail.resultType
-  #                 insightResults: $.detail.insightResults
-  #               InputTemplate: |
-  #                 "<insightName>"
-  #                 "Result Type: <resultType>"
-  #                 "Date/Time: <insightTime>"
-  #                 "Insight ARN: <insightArn>"
-  #                 "Action Name: <actionName>"
-  #                 "Action Description: <actionDescription>"
-  #                 ""
-  #                 "Insight Results:"
-  #                 "<insightResults>"
+  SecurityHubInsightsCWEvent:
+    Condition: SendSecurityHubEvents
+    Type: AWS::Events::Rule
+    Properties:
+        Description: GuardDuty Event Rule
+        EventPattern:
+          source:
+            - aws.securityhub
+          detail-type:
+            - Security Hub Insight Results
+        State: ENABLED
+        Targets:
+            - 
+              Arn: !Ref NotificationTopic
+              Id: TargetSNSTopic
+              InputTransformer:
+                InputPathsMap:
+                  insightTime: $.time
+                  actionName: $.detail.actionName
+                  actionDescription: $.detail.actionDescription
+                  insightArn: $.detail.insightArn
+                  insightName: $.detail.insightName
+                  resultType: $.detail.resultType
+                  insightResults: $.detail.insightResults
+                InputTemplate: |
+                  "<insightName>"
+                  "Result Type: <resultType>"
+                  "Date/Time: <insightTime>"
+                  "Insight ARN: <insightArn>"
+                  "Action Name: <actionName>"
+                  "Action Description: <actionDescription>"
+                  ""
+                  "Insight Results:"
+                  "<insightResults>"
 
 ######################################################################################################################################
 # Notifications

--- a/cfn/security-regional.yaml
+++ b/cfn/security-regional.yaml
@@ -135,79 +135,6 @@ Resources:
   SecurityHubHub:
     Type: "AWS::SecurityHub::Hub"
 
-  SecurityHubImportedCWEvent:
-    Type: AWS::Events::Rule
-    Properties:
-        Description: GuardDuty Event Rule
-        EventPattern:
-          source:
-            - aws.securityhub
-          detail-type:
-            - Security Hub Findings - Imported
-        State: ENABLED
-        Targets:
-            - 
-              Arn: !Ref NotificationTopic
-              Id: TargetSNSTopic
-              InputTransformer:
-                InputPathsMap:
-                  findingTime: $.detail.findings[0].updatedAt
-                  findingType: $.detail.findings[0].Types[0]
-                  findingId: $.detail.findings[0].Resources[0].Region
-                  findingTitle: $.detail.findings[0].Title
-                  findingDescription: $.detail.findings[0].Description
-                  complianceStatus: $.detail.findings[0].Compliance.Status
-                  affectedResources: $.detail.findings[0].Resources
-                  recommendationText: $.detail.findings[0].Recommendation.Text
-                  recommendationUrl: $.detail.findings[0].Recommendation.Url
-                InputTemplate: |
-                  "<findingTitle>"
-                  "Finding: <findingType>"
-                  "Date/Time: <findingTime>"
-                  "Finding ID: <findingId>"
-                  "Compliance Status: <complianceStatus>"
-                  "Description: <findingDescription>"
-                  ""
-                  "Affected Resource:"
-                  "<affectedResources>"
-                  ""
-                  "<recommendationText>"
-                  "<recommendationUrl>"
-
-  SecurityHubInsightsCWEvent:
-    Type: AWS::Events::Rule
-    Properties:
-        Description: GuardDuty Event Rule
-        EventPattern:
-          source:
-            - aws.securityhub
-          detail-type:
-            - Security Hub Insight Results
-        State: ENABLED
-        Targets:
-            - 
-              Arn: !Ref NotificationTopic
-              Id: TargetSNSTopic
-              InputTransformer:
-                InputPathsMap:
-                  insightTime: $.time
-                  actionName: $.detail.actionName
-                  actionDescription: $.detail.actionDescription
-                  insightArn: $.detail.insightArn
-                  insightName: $.detail.insightName
-                  resultType: $.detail.resultType
-                  insightResults: $.detail.insightResults
-                InputTemplate: |
-                  "<insightName>"
-                  "Result Type: <resultType>"
-                  "Date/Time: <insightTime>"
-                  "Insight ARN: <insightArn>"
-                  "Action Name: <actionName>"
-                  "Action Description: <actionDescription>"
-                  ""
-                  "Insight Results:"
-                  "<insightResults>"
-
   # Custom Resource to enable CIS Standards in Security Hub
   EnableCISFoundations:
     DependsOn: SecurityHubHub
@@ -254,6 +181,80 @@ Resources:
             elif event['RequestType'] == 'Update' or event['RequestType'] == 'Delete':
                 responseData['reason'] = 'No changes required.'
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, physicalResourceId)
+
+  # # Security Hub Notifications (disabled by default)
+  # SecurityHubImportedCWEvent:
+  #   Type: AWS::Events::Rule
+  #   Properties:
+  #       Description: GuardDuty Event Rule
+  #       EventPattern:
+  #         source:
+  #           - aws.securityhub
+  #         detail-type:
+  #           - Security Hub Findings - Imported
+  #       State: ENABLED
+  #       Targets:
+  #           - 
+  #             Arn: !Ref NotificationTopic
+  #             Id: TargetSNSTopic
+  #             InputTransformer:
+  #               InputPathsMap:
+  #                 findingTime: $.detail.findings[0].updatedAt
+  #                 findingType: $.detail.findings[0].Types[0]
+  #                 findingId: $.detail.findings[0].Resources[0].Region
+  #                 findingTitle: $.detail.findings[0].Title
+  #                 findingDescription: $.detail.findings[0].Description
+  #                 complianceStatus: $.detail.findings[0].Compliance.Status
+  #                 affectedResources: $.detail.findings[0].Resources
+  #                 recommendationText: $.detail.findings[0].Recommendation.Text
+  #                 recommendationUrl: $.detail.findings[0].Recommendation.Url
+  #               InputTemplate: |
+  #                 "<findingTitle>"
+  #                 "Finding: <findingType>"
+  #                 "Date/Time: <findingTime>"
+  #                 "Finding ID: <findingId>"
+  #                 "Compliance Status: <complianceStatus>"
+  #                 "Description: <findingDescription>"
+  #                 ""
+  #                 "Affected Resource:"
+  #                 "<affectedResources>"
+  #                 ""
+  #                 "<recommendationText>"
+  #                 "<recommendationUrl>"
+
+  # SecurityHubInsightsCWEvent:
+  #   Type: AWS::Events::Rule
+  #   Properties:
+  #       Description: GuardDuty Event Rule
+  #       EventPattern:
+  #         source:
+  #           - aws.securityhub
+  #         detail-type:
+  #           - Security Hub Insight Results
+  #       State: ENABLED
+  #       Targets:
+  #           - 
+  #             Arn: !Ref NotificationTopic
+  #             Id: TargetSNSTopic
+  #             InputTransformer:
+  #               InputPathsMap:
+  #                 insightTime: $.time
+  #                 actionName: $.detail.actionName
+  #                 actionDescription: $.detail.actionDescription
+  #                 insightArn: $.detail.insightArn
+  #                 insightName: $.detail.insightName
+  #                 resultType: $.detail.resultType
+  #                 insightResults: $.detail.insightResults
+  #               InputTemplate: |
+  #                 "<insightName>"
+  #                 "Result Type: <resultType>"
+  #                 "Date/Time: <insightTime>"
+  #                 "Insight ARN: <insightArn>"
+  #                 "Action Name: <actionName>"
+  #                 "Action Description: <actionDescription>"
+  #                 ""
+  #                 "Insight Results:"
+  #                 "<insightResults>"
 
 ######################################################################################################################################
 # Notifications


### PR DESCRIPTION
Due to no simple way to filter only on state changed to FAILED we're disabling security hub alerts to avoid overflow of alerts.
It is recommended to review the status in the Security Hub console from time to time but the CIS CloudWatch Alarms and GuardDuty still provide push notifications.