### PR TITLE
feat: remove lc transitions to save cost for many small objects

### DIFF
--- a/cfn/logging.yaml
+++ b/cfn/logging.yaml
@@ -70,14 +70,6 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      LifecycleConfiguration:
-        Rules:
-        - Id: GlacierRule
-          Status: Enabled
-          ExpirationInDays: 20
-          Transitions:
-            - TransitionInDays: 10
-              StorageClass: Glacier
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -127,14 +119,6 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      LifecycleConfiguration:
-        Rules:
-        - Id: GlacierRule
-          Status: Enabled
-          ExpirationInDays: 20
-          Transitions:
-            - TransitionInDays: 10
-              StorageClass: Glacier
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/cfn/logging.yaml
+++ b/cfn/logging.yaml
@@ -70,6 +70,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+        - Id: ExpirationRule
+          Status: Enabled
+          ExpirationInDays: 90
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -119,6 +124,11 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      LifecycleConfiguration:
+        Rules:
+        - Id: ExpirationRule
+          Status: Enabled
+          ExpirationInDays: 90
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/msb.config
+++ b/msb.config
@@ -2,7 +2,7 @@
 STACK_PREFIX="msb"
 
 # The AWS CLI profile to use for commands. This will impact the AWS Account you deploy to.
-AWS_PROFILE="default"
+AWS_PROFILE="wallbomk-msb"
 
 # The e-mail address to receive configuration and security alerts
-NOTIFICATION_EMAIL=""
+NOTIFICATION_EMAIL="wallbomk@amazon.com"


### PR DESCRIPTION
Since CloudTrail creates so many small files the cost of transitioning them ($/object rather than size) is quickly higher than the cost to keep them in S3 Standard.
Recommend removing these from the MSB and other decisions can be taken for more complex setups.